### PR TITLE
Fixed inverted mouse scrolling issue

### DIFF
--- a/scripts/install_fix.sh
+++ b/scripts/install_fix.sh
@@ -60,11 +60,11 @@ cat <<EOF > /etc/libinput.conf
 # libinput-config configuration
 override-compositor=enabled
 
-# Fixed scroll speed (0.3 is your preferred slower speed)
+# Fixed scroll speed (0.3 or 0.5 is your preferred slower speed)
 scroll-factor=0.3
 
 tap=enabled
-natural-scroll=enabled
+natural-scroll=disabled
 EOF
 
 echo "------------------------------------------------"


### PR DESCRIPTION
natural-scroll was making is seem like a phone (down scroll goes up and vice versa) but that is not the case for the mouse, so I disabled it to let gnome handle the direction on it's own without altering it on a global level.